### PR TITLE
Fixed UnboundLocalError In distance_detection

### DIFF
--- a/octoprint_smart_filament_sensor/__init__.py
+++ b/octoprint_smart_filament_sensor/__init__.py
@@ -411,17 +411,17 @@ class SmartFilamentSensor(octoprint.plugin.StartupPlugin,
             elif(gcode == "G92"):
                 if(self.detection_method == 1):
                     self.init_distance_detection()
-                self._logger.debug("Found G92 command in '" + command + "' : Reset Extruders")
+                self._logger.debug("Found G92 command in '" + gcode + "' : Reset Extruders")
 
             # M82 absolut extrusion mode
             elif(gcode == "M82"):
                 self._data.absolut_extrusion = True
-                self._logger.info("Found M82 command in '" + command + "' : Absolut extrusion")
+                self._logger.info("Found M82 command in '" + gcode + "' : Absolut extrusion")
 
             # M83 relative extrusion mode
             elif(gcode == "M83"):
                 self._data.absolut_extrusion = False
-                self._logger.info("Found M83 command in '" + command + "' : Relative extrusion")
+                self._logger.info("Found M83 command in '" + gcode + "' : Relative extrusion")
 
         return cmd
 

--- a/octoprint_smart_filament_sensor/__init__.py
+++ b/octoprint_smart_filament_sensor/__init__.py
@@ -411,17 +411,17 @@ class SmartFilamentSensor(octoprint.plugin.StartupPlugin,
             elif(gcode == "G92"):
                 if(self.detection_method == 1):
                     self.init_distance_detection()
-                self._logger.debug("Found G92 command in '" + gcode + "' : Reset Extruders")
+                self._logger.debug("Found G92 command in '" + cmd + "' : Reset Extruders")
 
             # M82 absolut extrusion mode
             elif(gcode == "M82"):
                 self._data.absolut_extrusion = True
-                self._logger.info("Found M82 command in '" + gcode + "' : Absolut extrusion")
+                self._logger.info("Found M82 command in '" + cmd + "' : Absolut extrusion")
 
             # M83 relative extrusion mode
             elif(gcode == "M83"):
                 self._data.absolut_extrusion = False
-                self._logger.info("Found M83 command in '" + gcode + "' : Relative extrusion")
+                self._logger.info("Found M83 command in '" + cmd + "' : Relative extrusion")
 
         return cmd
 


### PR DESCRIPTION
Plugin was not working.  After finding these errors in the log, just had to use the correct variable names.

`2022-03-02 20:20:59,203 - octoprint.util.comm - ERROR - Error while processing hook smartfilamentsensor for phase sent and command M83:
Traceback (most recent call last):
  File "/home/pi/oprint/lib/python3.7/site-packages/octoprint/util/comm.py", line 4611, in _process_command_phase
    tags=tags,
  File "/home/pi/oprint/lib/python3.7/site-packages/octoprint/util/__init__.py", line 1737, in wrapper
    return f(*args, **kwargs)
  File "/home/pi/oprint/lib/python3.7/site-packages/octoprint_smart_filament_sensor/__init__.py", line 424, in distance_detection
    self._logger.info("Found M83 command in '" + command + "' : Relative extrusion")
UnboundLocalError: local variable 'command' referenced before assignment
2022-03-02 20:20:59,215 - octoprint.util.comm - ERROR - Error while processing hook smartfilamentsensor for phase sent and command G1 E10 F300:
Traceback (most recent call last):
  File "/home/pi/oprint/lib/python3.7/site-packages/octoprint/util/comm.py", line 4611, in _process_command_phase
    tags=tags,
  File "/home/pi/oprint/lib/python3.7/site-packages/octoprint/util/__init__.py", line 1737, in wrapper
    return f(*args, **kwargs)
  File "/home/pi/oprint/lib/python3.7/site-packages/octoprint_smart_filament_sensor/__init__.py", line 407, in distance_detection
    self._logger.debug("Found extrude command in '" + commands + "' with value: " + extruder)
TypeError: can only concatenate str (not "list") to str
2022-03-02 20:20:59,222 - octoprint.util.comm - ERROR - Error while processing hook smartfilamentsensor for phase sent and command M82:
Traceback (most recent call last):
  File "/home/pi/oprint/lib/python3.7/site-packages/octoprint/util/comm.py", line 4611, in _process_command_phase
    tags=tags,
  File "/home/pi/oprint/lib/python3.7/site-packages/octoprint/util/__init__.py", line 1737, in wrapper
    return f(*args, **kwargs)
  File "/home/pi/oprint/lib/python3.7/site-packages/octoprint_smart_filament_sensor/__init__.py", line 419, in distance_detection
    self._logger.info("Found M82 command in '" + command + "' : Absolut extrusion")`