### PR TITLE
Add optional Dry Run mode - do nothing

### DIFF
--- a/octoprint_smart_filament_sensor/__init__.py
+++ b/octoprint_smart_filament_sensor/__init__.py
@@ -203,8 +203,9 @@ class SmartFilamentSensor(octoprint.plugin.StartupPlugin,
         if(not self.send_code):
             self._logger.error("Motion sensor detected no movement")
             self._logger.info("Pause command: " + self.pause_command)
-            self._printer.commands(self.pause_command)
-            self.send_code = True
+            if self.pause_command != "@DRY_RUN":
+                self._printer.commands(self.pause_command)
+                self.send_code = True
             self._data.filament_moving = False
             self.lastE = -1 # Set to -1 so it ignores the first test then continues
 

--- a/octoprint_smart_filament_sensor/templates/smartfilamentsensor_settings.jinja2
+++ b/octoprint_smart_filament_sensor/templates/smartfilamentsensor_settings.jinja2
@@ -36,6 +36,7 @@
                     <option value="M601">{{ _('M601 - Pause print') }}</option>
                     <option value="@pause">{{ _('@pause - Octoprint Pause') }}</option>         
                     <option value="@cancel">{{ _('@cancel - Octoprint Cancel') }}</option>
+                    <option value="@DRY_RUN">{{ _('@DRY_RUN - Do nothing') }}</option>
                 </select>
                 <span class="help-block"><small>Before selecting a pause command check if your firmware supports it!</small></span>
             </div>


### PR DESCRIPTION
Does what it says on the tin - add optional dry run mode which doesn't pause anything :) (normal logging operation, different to the "connection test")